### PR TITLE
Fixed logging and enabled passing the moira flag from the tinylicious config.

### DIFF
--- a/server/routerlicious/packages/services-utils/src/logger.ts
+++ b/server/routerlicious/packages/services-utils/src/logger.ts
@@ -67,3 +67,5 @@ export function configureLogging(configOrPath: nconf.Provider | string) {
         args[0] = `${name} ${args[0]}`;
     };
 }
+
+export {winston};

--- a/server/tinylicious/src/app.ts
+++ b/server/tinylicious/src/app.ts
@@ -15,7 +15,7 @@ import express, { Router } from "express";
 import safeStringify from "json-stringify-safe";
 import morgan from "morgan";
 import { Provider } from "nconf";
-import * as winston from "winston";
+import {winston} from "@fluidframework/server-services-utils"
 import { create as createRoutes } from "./routes";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports

--- a/server/tinylicious/src/resourcesFactory.ts
+++ b/server/tinylicious/src/resourcesFactory.ts
@@ -13,7 +13,7 @@ import * as git from "isomorphic-git";
 import { Provider } from "nconf";
 import socketIo from "socket.io";
 
-import winston from "winston";
+import {winston} from "@fluidframework/server-services-utils"
 import { TinyliciousResources } from "./resources";
 import {
     DbFactory,
@@ -61,7 +61,11 @@ export class TinyliciousResourcesFactory implements IResourcesFactory<Tinyliciou
                 return new Historian(url, false, false);
             },
             winston,
-            undefined /* serviceConfiguration */,
+            {
+                moira: {
+                    enable: config.get("moira:enable") || false
+                }
+            } /* serviceConfiguration */,
             pubsub);
 
         return new TinyliciousResources(

--- a/server/tinylicious/src/runner.ts
+++ b/server/tinylicious/src/runner.ts
@@ -15,7 +15,7 @@ import {
 } from "@fluidframework/server-services-core";
 import { Deferred } from "@fluidframework/common-utils";
 import { Provider } from "nconf";
-import * as winston from "winston";
+import { winston } from "@fluidframework/server-services-utils"
 import { configureWebSocketServices } from "@fluidframework/server-lambdas";
 import { TestClientManager } from "@fluidframework/server-test-utils";
 import detect from "detect-port";


### PR DESCRIPTION
This fixes logging (by using the same winson instance everywhere instead of creating a new one) and forwards the moira flag from the tinylicious config.json to the lambdas.